### PR TITLE
Fix RX streaming space required calculation

### DIFF
--- a/Streaming.cpp
+++ b/Streaming.cpp
@@ -90,7 +90,7 @@ void SoapySidekiq::rx_receive_operation(void) {
       uint32_t num_samples = (len - SKIQ_RX_HEADER_SIZE_IN_BYTES) / sizeof(int16_t);
 
       //  buffer space required
-      uint32_t space_req = num_samples * elementsPerSample * shortsPerWord;
+      uint32_t space_req = num_samples * shortsPerWord;
 
       //  buf mutex
       {
@@ -320,7 +320,7 @@ int SoapySidekiq::readStream(SoapySDR::Stream *stream,
   if (useShort) {
     std::memcpy(buff0, _currentBuff, returnedElems * elementsPerSample * sizeof(int16_t));
   } else {
-    std::memcpy(buff0, (float *) _currentBuff, returnedElems * 2 * sizeof(float));
+    std::memcpy(buff0, (float *) _currentBuff, returnedElems * elementsPerSample * sizeof(float));
   }
 
   //  bump variables for next call into readStream
@@ -441,7 +441,7 @@ int SoapySidekiq::acquireReadBuffer(SoapySDR::Stream *stream,
   if (_buf_count == 0) {
     _buf_cond.wait_for(lock, std::chrono::microseconds(timeoutUs));
     if (_buf_count == 0) {
-      SoapySDR_logf(SOAPY_SDR_WARNING, "Read Timeout occured after %d ms", timeoutUs);
+      SoapySDR_logf(SOAPY_SDR_WARNING, "Read Timeout occured after %d us", timeoutUs);
       return SOAPY_SDR_TIMEOUT;
     }
   }


### PR DESCRIPTION
The calculation to compute the space required to store the users samples is
double what it should be.

An example of how this can manifest from the users perspective, the Sidekiq SDR
reads 2036 samples of type `int16_t`/`float`, the internal Soapy Sidekiq buffer
will be resized to twice what is needed, samples are written to the first half
of the buffer, the 2nd half is all zeros. If you dump the samples received
from `SoapySidekiq::readStream`, you would see a pattern of 2036 samples
followed by 2036 samples consisting of zeros.

Instead, the `space_req` should be in terms of the number of 'samples' which
are I & Q samples.

There was a bit of confusion on my part as to what a sample represented. A
sample represents a single I or Q value. Something like a
`std::complex<float>`, which I initially assumed was a 'sample' is instead
referred to as an `elem` or `elements` in this code. Not a criticism but it
seems like different code bases represent a 'sample' differently.

This change was tested with:
- Sidekiq Stretch M.2-2280 (rev B), FPGA v3.15.1
- Sidekiq SDK v4.17.4
- Stream types `int16_t` (Soapy CS16) and `float` (Soapy CF32)

There are 3 additional unrelated changes in this commit:
- Replace magic number 2 with `elementsPerSample` in `memcpy` buffer size
calculation.
- Use microsecond unit name (us) when reporting timeout rather than reporting
as milliseconds unit name (ms).
- GitHub recommended adding a new line at the end of the file